### PR TITLE
[CIVP-20153] migrate mistral index

### DIFF
--- a/mistral/db/sqlalchemy/migration/alembic_migrations/versions/009_add_database_indices.py
+++ b/mistral/db/sqlalchemy/migration/alembic_migrations/versions/009_add_database_indices.py
@@ -218,3 +218,10 @@ def upgrade():
         ['scope'],
         unique=False
     )
+
+    op.create_index(
+        'action_executions_v2_workflow_name',
+        'action_executions_v2',
+        ['worklow_name'],
+        unique=False
+    )

--- a/mistral/db/sqlalchemy/migration/alembic_migrations/versions/009_add_database_indices.py
+++ b/mistral/db/sqlalchemy/migration/alembic_migrations/versions/009_add_database_indices.py
@@ -218,10 +218,3 @@ def upgrade():
         ['scope'],
         unique=False
     )
-
-    op.create_index(
-        'action_executions_v2_workflow_name',
-        'action_executions_v2',
-        ['worklow_name'],
-        unique=False
-    )

--- a/mistral/db/sqlalchemy/migration/alembic_migrations/versions/035_add_workflow_name_index.py
+++ b/mistral/db/sqlalchemy/migration/alembic_migrations/versions/035_add_workflow_name_index.py
@@ -17,6 +17,6 @@ def upgrade():
     op.create_index(
         'action_executions_v2_workflow_name',
         'action_executions_v2',
-        ['worklow_name'],
+        ['workflow_name'],
         unique=False
     )

--- a/mistral/db/sqlalchemy/migration/alembic_migrations/versions/035_add_workflow_name_index.py
+++ b/mistral/db/sqlalchemy/migration/alembic_migrations/versions/035_add_workflow_name_index.py
@@ -1,0 +1,22 @@
+"""Add workflow_name index in action_executions_v2 table
+
+Revision ID: 035
+Revises: 034
+Create Date: 2019-12-26 17:21:14.975474
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '035'
+down_revision = '034'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index(
+        'action_executions_v2_workflow_name',
+        'action_executions_v2',
+        ['worklow_name'],
+        unique=False
+    )


### PR DESCRIPTION
This PR adds a migration to create an index on the `workflow_name` column of the `action_executions_v2` table, in order to make our current production setup automatically reproducible.